### PR TITLE
add join discord link to nav

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,6 +33,16 @@ export default function Home() {
               tiktok
             </a>
           </li>
+          <li>
+            <a
+              href="https://discord.gg/VSrHTytUV9"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-sans text-5xl text-white tracking-wide transition-opacity hover:opacity-60 sm:text-6xl lg:text-7xl"
+            >
+              join discord
+            </a>
+          </li>
         </ul>
 
         {/* Email icon */}


### PR DESCRIPTION
Adds a "join discord" link to the bottom of the nav list, styled to match the existing twitch and tiktok links.

Closes #16

Generated with [Claude Code](https://claude.ai/code)