### PR TITLE
add youtube link to nav

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,6 +35,16 @@ export default function Home() {
           </li>
           <li>
             <a
+              href="https://www.youtube.com/@runi_bb"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-sans text-5xl text-white tracking-wide transition-opacity hover:opacity-60 sm:text-6xl lg:text-7xl"
+            >
+              youtube
+            </a>
+          </li>
+          <li>
+            <a
               href="https://discord.gg/VSrHTytUV9"
               target="_blank"
               rel="noopener noreferrer"


### PR DESCRIPTION
Adds a "youtube" link to the nav before the "join discord" link, pointing to https://www.youtube.com/@runi_bb.

Closes #18

Generated with [Claude Code](https://claude.ai/code)