### PR TITLE
Add stream schedule above the nav

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ export default function Home() {
       <nav className="relative z-10 flex h-full flex-col justify-end p-8 pb-12 sm:p-12 sm:pb-16 lowercase">
         {/* Stream schedule */}
         <p
-          className="mb-4 font-sans text-4xl text-white tracking-wide sm:text-5xl lg:text-6xl"
+          className="mb-10 font-sans text-4xl text-white tracking-wide sm:text-5xl lg:text-6xl"
           style={{ WebkitTextStroke: "2px black" }}
         >
           live on{" "}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,6 +34,14 @@ export default function Home() {
           </div>
         </div>
 
+        {/* Stream schedule */}
+        <p
+          className="mb-4 font-sans text-3xl text-white tracking-wide sm:text-4xl lg:text-5xl"
+          style={{ WebkitTextStroke: "2px black" }}
+        >
+          live on twitch every tues, weds, and fri at 6pm eastern
+        </p>
+
         <ul className="flex flex-col gap-3">
           <li>
             <a

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,10 +14,20 @@ export default function Home() {
       <nav className="relative z-10 flex h-full flex-col justify-end p-8 pb-12 sm:p-12 sm:pb-16 lowercase">
         {/* Stream schedule */}
         <p
-          className="mb-4 font-sans text-3xl text-white tracking-wide sm:text-4xl lg:text-5xl"
+          className="mb-4 font-sans text-4xl text-white tracking-wide sm:text-5xl lg:text-6xl"
           style={{ WebkitTextStroke: "2px black" }}
         >
-          live on twitch every tues, weds, and fri at 6pm eastern
+          live on{" "}
+          <a
+            href="https://www.twitch.tv/runi_bb"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline transition-opacity hover:opacity-60"
+            style={{ color: "#9146FF" }}
+          >
+            twitch
+          </a>{" "}
+          every tues, weds, and fri at 6pm eastern
         </p>
 
         {/* Latest YouTube video */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -80,7 +80,7 @@ export default function Home() {
               rel="noopener noreferrer"
               className="font-sans text-5xl text-white tracking-wide transition-opacity hover:opacity-60 sm:text-6xl lg:text-7xl"
             >
-              join discord
+              discord
             </a>
           </li>
         </ul>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,14 @@ export default function Home() {
 
       {/* Navigation Content */}
       <nav className="relative z-10 flex h-full flex-col justify-end p-8 pb-12 sm:p-12 sm:pb-16 lowercase">
+        {/* Stream schedule */}
+        <p
+          className="mb-4 font-sans text-3xl text-white tracking-wide sm:text-4xl lg:text-5xl"
+          style={{ WebkitTextStroke: "2px black" }}
+        >
+          live on twitch every tues, weds, and fri at 6pm eastern
+        </p>
+
         {/* Latest YouTube video */}
         <div className="mb-6 flex flex-col gap-3">
           <a
@@ -33,14 +41,6 @@ export default function Home() {
             />
           </div>
         </div>
-
-        {/* Stream schedule */}
-        <p
-          className="mb-4 font-sans text-3xl text-white tracking-wide sm:text-4xl lg:text-5xl"
-          style={{ WebkitTextStroke: "2px black" }}
-        >
-          live on twitch every tues, weds, and fri at 6pm eastern
-        </p>
 
         <ul className="flex flex-col gap-3">
           <li>


### PR DESCRIPTION
Adds a schedule line above the navigation links: "live on twitch every tues, weds, and fri at 6pm eastern" in the same font, slightly smaller, with a 2px black outline.

Resolves #22

Generated with [Claude Code](https://claude.ai/code)